### PR TITLE
Handling Incomplete Downloads

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -353,7 +353,15 @@ def start():
 def upload():
 	print("/upload")
 
-	file = flask.request.files["file"]
+	try:
+		file = flask.request.files["file"]
+		print("Received file")
+	except (ConnectionResetError, BrokenPipeError):
+		print("Connection reset by peer")
+		return flask.jsonify({"error": "Connection reset by peer"})
+	except Exception as e:
+		print("Error:", e)
+		return flask.jsonify({"error": str(e)})
 
 	base = flask.request.form.get("base")
 	model = flask.request.form.get("model")

--- a/backend/main.py
+++ b/backend/main.py
@@ -300,6 +300,7 @@ def delete(base):
 	
 	if trans.state in [
 		TranscriptionState.ERROR,
+		TranscriptionState.INIT,
 		TranscriptionState.CONVERTED,
 		TranscriptionState.TRANSCRIBING,
 		TranscriptionState.TRANSCRIBED

--- a/backend/main.py
+++ b/backend/main.py
@@ -354,12 +354,6 @@ def start():
 def upload():
 	print("/upload")
 
-	if "file" not in flask.request.files:
-		return flask.jsonify({"error": "No file provided"})
-	
-	if not util.allowed_file(flask.request.files["file"].filename, ALLOWED_EXTENSIONS):
-		return flask.jsonify({"error": "Invalid file type. Accepted types: " + ", ".join(ALLOWED_EXTENSIONS)})
-
 	try:
 		file = flask.request.files["file"]
 		print("Received file")
@@ -369,6 +363,12 @@ def upload():
 			db.execute("DELETE FROM transcriptions WHERE base = ?", (base,))
 			db.commit()
 		return flask.jsonify({"error": f"Upload failed: {e}"})
+	
+	if not file:
+		return flask.jsonify({"error": "No file provided"})
+	
+	if not util.allowed_file(file.filename, ALLOWED_EXTENSIONS):
+		return flask.jsonify({"error": "Invalid file type. Accepted types: " + ", ".join(ALLOWED_EXTENSIONS)})
 
 	base = flask.request.form.get("base")
 	model = flask.request.form.get("model")

--- a/backend/main.py
+++ b/backend/main.py
@@ -353,6 +353,12 @@ def start():
 def upload():
 	print("/upload")
 
+	if "file" not in flask.request.files:
+		return flask.jsonify({"error": "No file provided"})
+	
+	if not util.allowed_file(flask.request.files["file"].filename, ALLOWED_EXTENSIONS):
+		return flask.jsonify({"error": "Invalid file type. Accepted types: " + ", ".join(ALLOWED_EXTENSIONS)})
+
 	try:
 		file = flask.request.files["file"]
 		print("Received file")
@@ -367,11 +373,6 @@ def upload():
 	model = flask.request.form.get("model")
 	language = flask.request.form.get("language")
 
-	if not file:
-		return flask.jsonify({"error": "No file provided"})
-	
-	if not util.allowed_file(file.filename, ALLOWED_EXTENSIONS):
-		return flask.jsonify({"error": "Invalid file type. Accepted types: " + ", ".join(ALLOWED_EXTENSIONS)})
 	
 	with sql.get_db(DATABASE) as db:
 		cursor = db.execute("SELECT * FROM transcriptions WHERE base = ?", (base,))

--- a/backend/main.py
+++ b/backend/main.py
@@ -364,6 +364,7 @@ def upload():
 		file = flask.request.files["file"]
 		print("Received file")
 	except Exception as e:
+		print(f"Invalid file or a problem occurred: {e}")
 		with sql.get_db(DATABASE) as db:
 			db.execute("DELETE FROM transcriptions WHERE base = ?", (base,))
 			db.commit()

--- a/backend/main.py
+++ b/backend/main.py
@@ -362,12 +362,11 @@ def upload():
 	try:
 		file = flask.request.files["file"]
 		print("Received file")
-	except (ConnectionResetError, BrokenPipeError):
-		print("Connection reset by peer")
-		return flask.jsonify({"error": "Connection reset by peer"})
 	except Exception as e:
-		print("Error:", e)
-		return flask.jsonify({"error": str(e)})
+		with sql.get_db(DATABASE) as db:
+			db.execute("DELETE FROM transcriptions WHERE base = ?", (base,))
+			db.commit()
+		return flask.jsonify({"error": f"Upload failed: {e}"})
 
 	base = flask.request.form.get("base")
 	model = flask.request.form.get("model")

--- a/backend/main.py
+++ b/backend/main.py
@@ -372,6 +372,11 @@ def upload():
 	model = flask.request.form.get("model")
 	language = flask.request.form.get("language")
 
+	with sql.get_db(DATABASE) as db:
+		cursor = db.execute("SELECT COUNT(*) FROM transcriptions WHERE base = ?", (base,))
+		count = cursor.fetchone()[0]
+		if count == 0:
+			return flask.jsonify({"error": "Transcription not found"})
 	
 	with sql.get_db(DATABASE) as db:
 		cursor = db.execute("SELECT * FROM transcriptions WHERE base = ?", (base,))

--- a/backend/sql.py
+++ b/backend/sql.py
@@ -56,21 +56,8 @@ def reset_in_progress(db: sqlite3.Connection, upload_dir: str):
 			print(f"File not found: {filepath}")
 
 	# INIT -> deleted
-	cursor = db.execute("SELECT * FROM transcriptions WHERE state = ?", (TranscriptionState.INIT,))
-	transcriptions = [Transcription.from_dict(dict(row)) for row in cursor.fetchall()]
-
-	print("Deleting partially downloaded files:")
-	for trans in transcriptions:
-		filepath = os.path.join(upload_dir, trans.original_filename)
-
-		print(f"Deleting {filepath}")
-		try:
-			os.remove(filepath)
-		except FileNotFoundError:
-			print(f"File not found: {filepath}")
-
 	db.execute("DELETE FROM transcriptions WHERE state = ?", (TranscriptionState.INIT,))
-
+	db.commit()
 		
 	# CONVERTING -> DOWNLOADED
 	db.execute("UPDATE transcriptions SET state = ? WHERE state = ?", (TranscriptionState.DOWNLOADED, TranscriptionState.CONVERTING))

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -5,6 +5,7 @@
 	export let api;
 
 	const TRANSCRIPTION_STATE_ERROR        = -1;
+	const TRANSCRIPTION_STATE_INIT         = 0;
 	const TRANSCRIPTION_STATE_CONVERTED    = 3;
 	const TRANSCRIPTION_STATE_TRANSCRIBING = 4;
 	const TRANSCRIPTION_STATE_TRANSCRIBED  = 5;
@@ -546,7 +547,7 @@ select {
 					{/if}
 				</div>
 
-				{#if result.state == TRANSCRIPTION_STATE_CONVERTED || result.state == TRANSCRIPTION_STATE_TRANSCRIBING}
+				{#if result.state == TRANSCRIPTION_STATE_INIT || result.state == TRANSCRIPTION_STATE_CONVERTED || result.state == TRANSCRIPTION_STATE_TRANSCRIBING}
 					<button class="result-button" on:click|stopPropagation={() => deleteFile(result.base)}>Cancel</button>
 				{:else if result.state == TRANSCRIPTION_STATE_TRANSCRIBED || result.state == TRANSCRIPTION_STATE_ERROR}
 					<button class="result-button" on:click|stopPropagation={() => deleteFile(result.base)}>Delete</button>


### PR DESCRIPTION
- Can now cancel downloads
- Some incomplete/not super functional checks to detect if a file upload is incomplete (aka: user navigated away before upload finished)
- On init/startup, failed downloads are removed from the database